### PR TITLE
Adapt `@package _group_` to updated version of hydra library

### DIFF
--- a/config/dataset/conll2003.yaml
+++ b/config/dataset/conll2003.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package dataset
 
 _target_: datasets.load_dataset
 path: conll2003

--- a/config/dataset/fewnerd.yaml
+++ b/config/dataset/fewnerd.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package dataset
 
 _target_: datasets.load_dataset
 path: dfki-nlp/few-nerd

--- a/config/dataset/germaner.yaml
+++ b/config/dataset/germaner.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package dataset
 
 _target_: datasets.load_dataset
 path: germaner

--- a/config/dataset/lenovo.yaml
+++ b/config/dataset/lenovo.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package dataset
 
 _target_: datasets.load_dataset
 path: ./datasets/lenovo.py

--- a/config/dataset/ontonotes.yaml
+++ b/config/dataset/ontonotes.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package dataset
 
 _target_: datasets.load_dataset
 path: ./datasets/ontonotes.py

--- a/config/dataset/smartdata.yaml
+++ b/config/dataset/smartdata.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package dataset
 
 _target_: datasets.load_dataset
 path: smartdata

--- a/config/dataset/wikiann.yaml
+++ b/config/dataset/wikiann.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package dataset
 
 _target_: datasets.load_dataset
 path: wikiann

--- a/config/dataset/wikigold.yaml
+++ b/config/dataset/wikigold.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package dataset
 
 _target_: datasets.load_dataset
 path: ./datasets/wikigold.py

--- a/config/dataset/wnut17.yaml
+++ b/config/dataset/wnut17.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package dataset
 
 _target_: datasets.load_dataset
 path: wnut_17

--- a/config/dataset_processor/albert.yaml
+++ b/config/dataset_processor/albert.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package dataset_processor
 
 _target_: fewie.dataset_processors.transformer.TransformerProcessor
 tokenizer_name_or_path: albert-base-v2 

--- a/config/dataset_processor/bert-german.yaml
+++ b/config/dataset_processor/bert-german.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package dataset_processor
 
 _target_: fewie.dataset_processors.transformer.TransformerProcessor
 tokenizer_name_or_path: dbmdz/bert-base-german-uncased

--- a/config/dataset_processor/bert.yaml
+++ b/config/dataset_processor/bert.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package dataset_processor
 
 _target_: fewie.dataset_processors.transformer.TransformerProcessor
 tokenizer_name_or_path: bert-base-uncased

--- a/config/dataset_processor/gottbert.yaml
+++ b/config/dataset_processor/gottbert.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package dataset_processor
 
 _target_: fewie.dataset_processors.gottbert.GottBERTProcessor
 tokenizer_name_or_path: uklfr/gottbert-base

--- a/config/dataset_processor/roberta.yaml
+++ b/config/dataset_processor/roberta.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package dataset_processor
 
 _target_: fewie.dataset_processors.roberta.RobertaProcessor
 tokenizer_name_or_path: roberta-base

--- a/config/dataset_processor/spanbert.yaml
+++ b/config/dataset_processor/spanbert.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package dataset_processor
 
 _target_: fewie.dataset_processors.transformer.TransformerProcessor
 tokenizer_name_or_path: SpanBERT/spanbert-base-cased

--- a/config/dataset_processor/transformer.yaml
+++ b/config/dataset_processor/transformer.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package dataset_processor
 
 _target_: fewie.dataset_processors.transformer.TransformerProcessor
 tokenizer_name_or_path: ??

--- a/config/dataset_processor/xlnet.yaml
+++ b/config/dataset_processor/xlnet.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package dataset_processor
 
 _target_: fewie.dataset_processors.transformer.TransformerProcessor
 tokenizer_name_or_path: xlnet-base-cased

--- a/config/encoder/albert.yaml
+++ b/config/encoder/albert.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package encoder
 
 
 _target_: fewie.encoders.albert.AlbertEncoder

--- a/config/encoder/bert-german.yaml
+++ b/config/encoder/bert-german.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package encoder
 
 _target_: fewie.encoders.transformer.TransformerEncoder
 model_name_or_path: dbmdz/bert-base-german-uncased

--- a/config/encoder/bert.yaml
+++ b/config/encoder/bert.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package encoder
 
 _target_: fewie.encoders.transformer.TransformerEncoder
 model_name_or_path: bert-base-uncased

--- a/config/encoder/gottbert.yaml
+++ b/config/encoder/gottbert.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package encoder
 
 _target_: fewie.encoders.transformer.TransformerEncoder
 model_name_or_path: uklfr/gottbert-base

--- a/config/encoder/random.yaml
+++ b/config/encoder/random.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package encoder
 
 _target_: fewie.encoders.random.RandomEncoder
 embedding_dim: 768

--- a/config/encoder/roberta.yaml
+++ b/config/encoder/roberta.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package encoder
 
 _target_: fewie.encoders.roberta.RobertaEncoder
 model_name_or_path: roberta-base

--- a/config/encoder/spanbert.yaml
+++ b/config/encoder/spanbert.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package encoder
 
 _target_: fewie.encoders.transformer.TransformerEncoder
 model_name_or_path: SpanBERT/spanbert-base-cased

--- a/config/encoder/transformer.yaml
+++ b/config/encoder/transformer.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package encoder
 
 _target_: fewie.encoders.transformer.TransformerEncoder
 model_name_or_path: ???

--- a/config/encoder/xlnet.yaml
+++ b/config/encoder/xlnet.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package encoder
 
 _target_: fewie.encoders.transformer.TransformerEncoder
 model_name_or_path: xlnet-base-cased 

--- a/config/evaluation/classifier/logistic_regression.yaml
+++ b/config/evaluation/classifier/logistic_regression.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package evaluation.classifier
 
 _target_: fewie.evaluation.classifiers.logistic_regression.LogisticRegression
 C: 1.0

--- a/config/evaluation/dataset/nway_kshot.yaml
+++ b/config/evaluation/dataset/nway_kshot.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package evaluation.dataset
 
 _target_: fewie.data.datasets.generic.nway_kshot.NwayKshotDataset
 n_ways: 5

--- a/config/evaluation/dataset/nway_kshot_5_1.yaml
+++ b/config/evaluation/dataset/nway_kshot_5_1.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package evaluation.dataset
 
 _target_: fewie.data.datasets.generic.nway_kshot.NwayKshotDataset
 n_ways: 5

--- a/config/evaluation/dataset/nway_kshot_5_10.yaml
+++ b/config/evaluation/dataset/nway_kshot_5_10.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package evaluation.dataset
 
 _target_: fewie.data.datasets.generic.nway_kshot.NwayKshotDataset
 n_ways: 5

--- a/config/evaluation/dataset/nway_kshot_5_5.yaml
+++ b/config/evaluation/dataset/nway_kshot_5_5.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package evaluation.dataset
 
 _target_: fewie.data.datasets.generic.nway_kshot.NwayKshotDataset
 n_ways: 5

--- a/config/evaluation/dataset/nway_kshot_na_dedicated.yaml
+++ b/config/evaluation/dataset/nway_kshot_na_dedicated.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package evaluation.dataset
 
 _target_: fewie.data.datasets.generic.nway_kshot.NwayKshotNaDedicatedDataset
 n_ways: 5

--- a/config/evaluation/dataset/nway_kshot_na_rest.yaml
+++ b/config/evaluation/dataset/nway_kshot_na_rest.yaml
@@ -1,4 +1,4 @@
-# @package _group_
+# @package evaluation.dataset
 
 _target_: fewie.data.datasets.generic.nway_kshot.NwayKshotNaRestDataset
 n_ways: 5


### PR DESCRIPTION
According to latest `hydra` [update](https://hydra.cc/docs/next/upgrades/1.0_to_1.1/changes_to_package_header/), it is necessary to adapt name: `@package _group_` to make config file compatible with both hydra 1.0 and 1.1