### PR TITLE
Add option to ignore O-class when building query set

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,6 +3,7 @@ cuda_device: 0
 batch_size: 1
 text_column_name: tokens
 label_column_name: ner_tags
+ignore_O: true
 scenario:
   name: few_shot_linear_readout
   metrics:

--- a/datasets/conll-de.py
+++ b/datasets/conll-de.py
@@ -107,7 +107,7 @@ class CoNLL(datasets.GeneratorBasedBuilder):
                     # organize a record to be written into json
                     record = {
                         "id": str(id),
-                        "tokens": tokens,                     
+                        "tokens": tokens,
                         "ner_tags": ner_tags,
                     }
                     tokens, ner_tags = [], []

--- a/src/fewie/eval.py
+++ b/src/fewie/eval.py
@@ -73,6 +73,7 @@ def evaluate_config(cfg: DictConfig) -> Dict[str, Any]:
             device=device,
             batch_size=cfg.batch_size,
             metrics=cfg.scenario.metrics,
+            ignore_O=cfg.ignore_O,
         )
     else:
         raise ValueError("Unknown evaluation scenario {}".format(cfg.scenario))


### PR DESCRIPTION
According to https://github.com/flairNLP/flair/issues/318, we choose not to take O-tokens into consideration when computing F1-scores.